### PR TITLE
Reverting the BsidesSF 2019 specific branding, colors and info

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,10 +9,10 @@ description: >
 url: https://bsidessf.org
 
 header: yes
-header_sm: images/logos_2019/2019-header-sm.png
-header_med: images/logos_2019/2019-header-med.png
-header_large: images/logos_2019/2019-header-lg.png
-header_xl: images/logos_2019/2019-header-xl.png
+header_sm: images/bsides_logo_full-orangeblack.png
+header_med: images/bsides_logo_full-orangeblack.png
+header_large: images/bsides_logo_full-orangeblack.png
+header_xl: images/bsides_logo_full-orangeblack.png
 
 # Exclude our ruby stuff and other files
 exclude: [.bundle, bin, vendor, Gemfile, Gemfile.lock, Rakefile, .last_optimized, CNAME, README.md, LICENSE]
@@ -46,9 +46,8 @@ google_universal_analytics_cookiedomain: auto
 facebook_app_id: 1522022128111003
 facebook_locale: en_US
 facebook_type: website
-facebook_image: /images/logos_2019/bsides_logo_short_2019.png
-
+facebook_image: /images/bsides_logo_short.png
 # Twitter Cards
 twitter_user: "@BSidesSF"
 twitter_card: true
-twitter_image: /images/logos_2019/bsides_logo_short_2019.png
+twitter_image: /images/bsides_logo_short.png

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -22,17 +22,6 @@
     - subtitle: "Donate"
       subhref: "/donate.html"
 
-- title: "Venue"
-  href: "/venue.html"
-
 - title: "Sponsors"
   href: "/sponsors.html"
 
-- title: "Volunteer"
-  href: "/volunteer.html"
-
-- title: "Schedule"
-  href: "/schedule.html"
-
-- title: "Tickets"
-  href: "/tickets.html"

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,6 +1,6 @@
 // Base Colors
 $primary-color: #272727;
-$secondary-color: #6d9d2f;
+$secondary-color: #cd502b;
 $complimentary-color: #fff;
 $body-bg: #fff;
 $body-font-color: #222;
@@ -8,7 +8,7 @@ $body-font-color: #222;
 // Links
 $link-color: $secondary-color;
 $link-hover-color: $body-font-color;
-$link-visited-color: #8fc845;
+$link-visited-color: #cd502b;
 
 // Text
 $base-font-family: Helvetica, Arial, sans-serif;

--- a/index.html
+++ b/index.html
@@ -5,26 +5,14 @@ layout: default
 <article class="row">
   <section class="small-12 large-8 columns page-content">
 
-    <h2><b>BSidesSF 2019</b></h2>
+    <h2><b>BSidesSF</b></h2>
 
     <p>
-       We are excited to announce that BSidesSF will take place March 3rd and 4th, 2019 at City View at Metreon. This year's theme is 80s tech/games.<br/>
+       A big thank you to all of our sponsors, volunteers and participants who helped make BSidesSF 2019 such a great event.<br/>
     </p>
 
     <p>
-       Get your tickets to join <a href="https://www.iamthecavalry.org/">I Am The Calvary</a> for <a href="/hackers.html"> private showing of Hackers</a> following the closing ceremony on Monday.
-    </p>
-
-    <p>
-       Tickets are now available! <a href="/tickets.html">Get yours now.</a>
-    </p>
-
-    <p>
-       Want a free ticket? <a href="/volunteer.html">Volunteer at BSidesSF!</a>
-    </p>
-
-    <p>
-       Want to sponsor? Check out our <a href="sponsors.html#interested-in-sponsoring">Sponsorship Kit</a> now.<br/>
+       We're already starting preperations for BsidesSF 2020. Stay tuned to this space for new updates!<br/>
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@ layout: default
     <h2><b>BSidesSF</b></h2>
 
     <p>
-       A big thank you to all of our sponsors, volunteers and participants who helped make BSidesSF 2019 such a great event.<br/>
+       A big thank you to all of our sponsors, volunteers, and participants who helped make BSidesSF 2019 such a great event.<br/>
     </p>
 
     <p>
-       We're already starting preperations for BsidesSF 2020. Stay tuned to this space for new updates!<br/>
+       BSidesSF 2020 will be held February 23-24, 2020. Preparations are already in the works to make our 10-year anniversary our best BSidesSF yet! Our theme will be San Francisco. Stay tuned to this space for new updates!<br/>
     </p>
 
     <p>


### PR DESCRIPTION
Reverting most of the BSidesSF 2019 stuff to clear the slate for BsidesSF 2020 stuff yet to come.

Screenshots:

![screenshot from 2019-03-07 11-29-39](https://user-images.githubusercontent.com/7587027/53984064-6ba59d80-40cd-11e9-8678-00284ea676f9.png)
![screenshot from 2019-03-07 11-30-41](https://user-images.githubusercontent.com/7587027/53984065-6ba59d80-40cd-11e9-9b86-49a395c9990d.png)
![screenshot from 2019-03-07 11-40-16](https://user-images.githubusercontent.com/7587027/53984239-d0f98e80-40cd-11e9-87e9-65bf449fe361.png)
![screenshot from 2019-03-07 11-31-15](https://user-images.githubusercontent.com/7587027/53984066-6ba59d80-40cd-11e9-9248-fcbb934457f1.png)
