### PR TITLE
Opening the Call for Participation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ destination: _site
 
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 
 feed:
   path: atom.xml

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -22,7 +22,7 @@
     - subtitle: "Donate"
       subhref: "/donate.html"
 
-- title: "Call For Participation"
+- title: "CFP"
   href: "/cfp.html"
 
 - title: "Sponsors"

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -22,6 +22,9 @@
     - subtitle: "Donate"
       subhref: "/donate.html"
 
+- title: "Call For Participation"
+  href: "/cfp.html"
+
 - title: "Sponsors"
   href: "/sponsors.html"
 

--- a/cfp.md
+++ b/cfp.md
@@ -14,7 +14,7 @@ We are a practitioner focused event that attracts a wide range of attendees rang
 
 The BSides community has continuously raised the bar and put the info back in infosec. We thank each and every member/participant/organizer of this community for their hard work, sweat, and relentless pursuit of making high quality content accessible. We celebrate diverse approaches and points of view and believe that our commitment to diversity fosters innovation. BSidesSF is continuing to build upon a culture that drives our community to include a wide range of thoughts and ideas.
 
-**When:**  BSidesSF will take place in San Francisco from February 22-24, 2020.  The Call For Participation for talks and workshops will close on November 6, 2019 at 11:59 PM PST.
+**When:**  BSidesSF will take place in San Francisco from February 22-24, 2020; Workshops on February 22, Conference Talks February 23-24. The Call For Participation for talks and workshops will close on November 6, 2019 at 11:59 PM PST.
 
 **How** 
 This year, we are expanding the type of submissions we are supporting at BSidesSF. New session types include deep dive talks, lightning talks, and an off the record track. 

--- a/cfp.md
+++ b/cfp.md
@@ -1,9 +1,64 @@
 ---
 layout: page
-title: "BSidesSF 2019 Call For Papers"
+title: "BSidesSF 2020 Call For Participation"
 permalink: /cfp.html
+redirect_from: "/cfw"
+redirect_from: "/cfw.html"
 --- 
 
-The BSidesSF 2019 CFP is now closed. See all our amazing speakers March 3-4, 2019 at the City View at Metreon in San Francisco. 
+**What:** BSidesSF 2020 Call For Participation for Talks and Workshops
 
-As always -- Questions? E-mail cfp [at] bsidessf.org
+BSidesSF is a non-profit organization designed to advance the body of Information Security knowledge, by providing an annual, open forum for discussion and debate for security practitioners. We produce a conference that is a source of education, collaboration, and continued conversation for information technologists. The technical and academic presentations at BSidesSF are given in the spirit of peer review and advanced knowledge dissemination. This allows the field of Information Security to grow in breadth and depth, and continue in its pursuit of highly advanced, scientifically based knowledge. 
+
+We are a practitioner focused event that attracts a wide range of attendees ranging from engineers & security leaders to executive decision makers. This is a great opportunity for you to showcase your work and share your ideas with industry peers. Bonus points if you can tie your presentation to this year’s conference theme: San Francisco! 
+
+The BSides community has continuously raised the bar and put the info back in infosec. We thank each and every member/participant/organizer of this community for their hard work, sweat, and relentless pursuit of making high quality content accessible. We celebrate diverse approaches and points of view and believe that our commitment to diversity fosters innovation. BSidesSF is continuing to build upon a culture that drives our community to include a wide range of thoughts and ideas.
+
+**When:**  BSidesSF will take place in San Francisco from February 22-24, 2020.  The Call for Participation for talks and workshops will close on November 6, 2019 at 11:59 PM PST.
+
+**How** 
+This year, we are expanding the type of submissions we are supporting at BSidesSF. New session types include deep dive talks, lightning talks and an off the record track. 
+
+**Workshops: February 22, 2020** 
+Please note that workshops will be held on Saturday, February 22, 2020 at a different location.
+
+- **Condensed workshops** - 2 hr 45 mins
+- **Full length workshops** - 5 hr 30 mins 
+
+**Talks: February 23-24, 2020**
+Please note that all talks are limited to two speakers only. Panels are limited to 5 participants (including the moderator).
+ 
+- **General talks** - 25 min regular talk format for various topics in security and privacy.
+- **Deep dive talks** - 50 min talk format to cover more technical deep dives.
+- **Panels** -  50 min panel discussion to bring together a group of experts on a broadly accessible topic.
+- **Lightning talks** - 10 min lightning talk about a new idea or project that you are exploring.
+- **Off the record** - 25 min or 50 min talks for topics that you would like to discuss “Off the record”. We will be enforcing no recording/photography for this track.   
+
+**Important Dates**
+- September 25, 2019 – Call for submissions opens
+- October 16, 2019 – Papers and Workshop proposals for early-bird consideration due
+- October 30, 2019 – First round speakers and trainers notified
+- November 6, 2019 – Final due date for all submissions
+- November 24, 2019 – Notifications sent
+- December 4, 2019 - Participation confirmed by speakers and details finalized
+- February 22-24, 2020 – BSidesSF 2020
+
+## What You Need
+- Speaker name(s) and contact information
+- Bio(s) 
+- Submission Title
+- Abstract - Limited to 200 words
+- Detailed Outline and Key Takeaways - Tell us more details about your presentation and why people will want to attend. These details will help us make an informed decision about your submission. 
+- T-shirt size(s) 
+- Are you interested in working with a program committee member for a dry run? 
+- Would you like to donate your speaker gift to one of our charities? 
+- Scheduling preferences 
+
+## To Submit
+
+[Submit a Talk](https://www.papercall.io/bsidessf-2020)
+
+[Submit a Workshop](https://forms.gle/mjgApRdV2S9WATZp8)
+
+
+Questions? E-mail program [at] bsidessf.org

--- a/cfp.md
+++ b/cfp.md
@@ -14,10 +14,10 @@ We are a practitioner focused event that attracts a wide range of attendees rang
 
 The BSides community has continuously raised the bar and put the info back in infosec. We thank each and every member/participant/organizer of this community for their hard work, sweat, and relentless pursuit of making high quality content accessible. We celebrate diverse approaches and points of view and believe that our commitment to diversity fosters innovation. BSidesSF is continuing to build upon a culture that drives our community to include a wide range of thoughts and ideas.
 
-**When:**  BSidesSF will take place in San Francisco from February 22-24, 2020.  The Call for Participation for talks and workshops will close on November 6, 2019 at 11:59 PM PST.
+**When:**  BSidesSF will take place in San Francisco from February 22-24, 2020.  The Call For Participation for talks and workshops will close on November 6, 2019 at 11:59 PM PST.
 
 **How** 
-This year, we are expanding the type of submissions we are supporting at BSidesSF. New session types include deep dive talks, lightning talks and an off the record track. 
+This year, we are expanding the type of submissions we are supporting at BSidesSF. New session types include deep dive talks, lightning talks, and an off the record track. 
 
 **Workshops: February 22, 2020** 
 Please note that workshops will be held on Saturday, February 22, 2020 at a different location.
@@ -32,7 +32,7 @@ Please note that all talks are limited to two speakers only. Panels are limited 
 - **Deep dive talks** - 50 min talk format to cover more technical deep dives.
 - **Panels** -  50 min panel discussion to bring together a group of experts on a broadly accessible topic.
 - **Lightning talks** - 10 min lightning talk about a new idea or project that you are exploring.
-- **Off the record** - 25 min or 50 min talks for topics that you would like to discuss “Off the record”. We will be enforcing no recording/photography for this track.   
+- **Off the record** - 25 min or 50 min talks for topics that you would like to discuss "Off the record". We will be enforcing no recording/photography for this track.   
 
 **Important Dates**
 - September 25, 2019 – Call for submissions opens

--- a/cfw.md
+++ b/cfw.md
@@ -1,9 +1,7 @@
 ---
 layout: page
-title: "BSidesSF 2019 Call For Workshops"
+title: "BSidesSF 2020 Call For Workshops"
 permalink: /cfw.html
 --- 
 
-The BsidesSF 2019 CFW is now closed. BSidesSF workshops will take place in San Francisco on March 2, 2019.
-
-As always -- Questions? E-mail workshops [at] bsidessf.org
+Please see details for submitting a 2020 Workshop at our [Call for Participation](https://bsidessf.org/cfp.html)

--- a/cfw.md
+++ b/cfw.md
@@ -4,4 +4,4 @@ title: "BSidesSF 2020 Call For Workshops"
 permalink: /cfw.html
 --- 
 
-Please see details for submitting a 2020 Workshop at our [Call for Participation](https://bsidessf.org/cfp.html)
+Please see details for submitting a 2020 Workshop at our [Call For Participation](https://bsidessf.org/cfp.html)

--- a/cfw.md
+++ b/cfw.md
@@ -4,4 +4,4 @@ title: "BSidesSF 2020 Call For Workshops"
 permalink: /cfw.html
 --- 
 
-Please see details for submitting a 2020 Workshop at our [Call For Participation](https://bsidessf.org/cfp.html)
+Please see details for submitting a 2020 Workshop at our [Call For Participation](/cfp.html)

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <h2><b>BSidesSF</b></h2>
 
     <p>
-      BSidesSF 2020 Call For participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community, please submit an entry to our <a href="/cfp.html">Call For Participation</a>.<br/>
+      BSidesSF 2020 Call For Participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community, please submit an entry to our <a href="/cfp.html">Call For Participation</a>.<br/>
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <h2><b>BSidesSF</b></h2>
 
     <p>
-       A big thank you to all of our sponsors, volunteers, and participants who helped make BSidesSF 2019 such a great event.<br/>
+      BSidesSF 2020 Call for participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community please submit an entry to our <a hfef="/cfp.html">Call for Participation</a>.<br/>
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <h2><b>BSidesSF</b></h2>
 
     <p>
-      BSidesSF 2020 Call for participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community please submit an entry to our <a hfef="/cfp.html">Call For Participation</a>.<br/>
+      BSidesSF 2020 Call For participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community, please submit an entry to our <a href="/cfp.html">Call For Participation</a>.<br/>
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <h2><b>BSidesSF</b></h2>
 
     <p>
-      BSidesSF 2020 Call for participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community please submit an entry to our <a hfef="/cfp.html">Call for Participation</a>.<br/>
+      BSidesSF 2020 Call for participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community please submit an entry to our <a hfef="/cfp.html">Call For Participation</a>.<br/>
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: default
     </p>
 
     <p>
-       BSidesSF 2020 will be held February 23-24, 2020. Preparations are already in the works to make our 10-year anniversary our best BSidesSF yet! Our theme will be San Francisco. Stay tuned to this space for new updates!<br/>
+       BSidesSF 2020 will be held February 22-24, 2020; Workshops on February 22, Conference Talks February 23-24. Preparations are already in the works to make our 10-year anniversary our best BSidesSF yet! Our theme will be San Francisco. Stay tuned to this space for new updates!<br/>
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <h2><b>BSidesSF</b></h2>
 
     <p>
-      BSidesSF 2020 Call For Participation is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community, please submit an entry to our <a href="/cfp.html">Call For Participation</a>.<br/>
+       The CFP for BSidesSF 2020 is <b>now open!</b> If you have a talk or workshop that you would like to bring to the community, please submit an entry to our <a href="/cfp.html">Call For Participation</a>.<br/>
     </p>
 
     <p>


### PR DESCRIPTION
Opening up the Call for Participation. Edits include:

- Slight copy change to the front page with the link to cfp.html
- redircting cfw/cfw.html to cfp.html (we're consolidating both CFP & CFW into a single page)
- Added Call for Participation to the main nacv
- And updated the copy for cfp.html for our 2020 copy.