### PR TITLE
Some edits to "Past Events"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To run the site locally, run ```bundle exec jekyll serve``` or ```rake watch``` 
 Adding pages
 ============
 
-You can create a new pages in \_pages, which will generate the page at the root of the site.  The top of your page (md or html) should look like:
+You can create a new page in \_pages, which will generate the page at the root of the site.  The top of your page (md or html) should look like:
 
 ```
 ---

--- a/_data/history.yml
+++ b/_data/history.yml
@@ -1,0 +1,72 @@
+### format is:
+#
+# - year: ####  (year becomes a title under "Past Years")
+#   categories:
+#      - title: "Nav Name"
+#        href: "/relative/path.html"
+#
+###
+
+- "year": "2019"
+  categories:
+    - title: "Posters"
+      href: "/graphic-recordings/2019.html"
+    - title: "Schedule"
+      external: "https://bsidessf2019.sched.com/"
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/132743652/BSidesSF2019"
+
+- "year": "2018"
+  categories:
+    - title: "Posters"
+      href: "/graphic-recordings/2018.html"
+    - title: "Schedule"
+      external: "https://bsidessf2018.sched.com"
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/122163258/BSidesSF2018"
+
+- "year": "2017"
+  categories:
+    - title: "Schedule"
+      external: "https://bsidessf2017.sched.com/"
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/111866644/BSidesSF2017"
+
+- year: "2016"
+  categories:
+    - title: "Schedule"
+      external: "https://bsidessf2016.sched.com/"
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/103445197/BSidesSF2016"
+
+- year: "2015"
+  categories:
+    - title: "Schedule"
+      external: "https://bsidessf2015.sched.com/"
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/90944586/BSidesSF2015"
+
+- year: "2014"
+  categories:
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/70849271/BSidesSF2014"
+
+- year: "2013"
+  categories:
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/35868077/BSidesSanFrancisco2013"
+
+- year: "2012"
+  categories:
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/47572893/BSidesSanFrancisco2012"
+
+- year: "2011"
+  categories:
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/56409738/BSidesSanFrancisco2011"
+
+- year: "2010"
+  categories:
+    - title: "Security BSides Wiki"
+      external: "http://www.securitybsides.com/w/page/12194147/BSidesSanFrancisco01"

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -4,4 +4,3 @@ title: "404"
 --- 
 
 # You Seem Lost
-

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -4,3 +4,4 @@ title: "404"
 --- 
 
 # You Seem Lost
+

--- a/_pages/about/past-events.md
+++ b/_pages/about/past-events.md
@@ -1,26 +1,16 @@
 ---
 layout: page
 title: "Past Events"
---- 
+---
 
-**Past BSidesSF**
-
-[Sunday, March 3 - Monday, March 4, 2019](http://www.securitybsides.com/w/page/132743652/BSidesSF2019)
-
-[Sunday, April 15 - Monday, April 16, 2018](http://www.securitybsides.com/w/page/122163258/BSidesSF2018)
-
-[Sunday, February 12 - Monday, February 13, 2017](http://www.securitybsides.com/w/page/111866644/BSidesSF2017)
-
-[Sunday, February 28 - Monday, February 29, 2016](http://www.securitybsides.com/w/page/103445197/BSidesSF2016)
-
-[Sunday, April 19 - Monday, April 20, 2015](http://www.securitybsides.com/w/page/90944586/BSidesSF2015)
-
-[Sunday, February 23 - Monday, February 24, 2014](http://www.securitybsides.com/w/page/70849271/BSidesSF2014)
-
-[Sunday, February 24- Monday, February 25, 2013](http://www.securitybsides.com/w/page/35868077/BSidesSanFrancisco2013)
-
-[Monday, February 27 - Tuesday, February 28, 2012](http://www.securitybsides.com/w/page/47572893/BSidesSanFrancisco2012)
-
-[Monday, February 14 - Tuesday, February 15, 2011](http://www.securitybsides.com/w/page/56409738/BSidesSanFrancisco2011)
-
-[Tuesday, March 2 - Wednesday, March 3, 2010](http://www.securitybsides.com/w/page/12194147/BSidesSanFrancisco01)
+{% for hist in site.data.history %}
+* {{ hist.year }}:
+  {% for cat in hist.categories %}
+  {% if cat.href %}
+  * <a href="{{ cat.href }}">{{ cat.title }}</a>
+  {% endif %}
+  {% if cat.external %}
+  * <a href="{{ cat.external }}">{{ cat.title }} (external)</a>
+  {% endif %}
+  {% endfor %}
+{% endfor %}


### PR DESCRIPTION
Was originally trying to figure out a way to put "Past Events" as a nav item.
Then realized that we already have a page for it, just not a lot of information on it.

Using the history.yaml file, we can now have an arbitrary set of links for our past years, including links to pages for our previous sponsors, artwork, t-shirts, etc.

For future years maybe we can save the set of pages we create and have the previous website mostly available and working through this.