### PR TITLE
CTF: Redirect to Scoreboard

### DIFF
--- a/_pages/ctf.md
+++ b/_pages/ctf.md
@@ -6,4 +6,10 @@ title: "Capture The Flag (CTF)"
 # CTF is coming back to BSidesSF 2020!
 # Special thanks to Google Cloud for providing hosting services.
 
+Please see [https://ctf.bsidessf.net/](https://ctf.bsidessf.net) for scoreboard, challenges, and details.
+
+<script markdown="0" type="text/javascript">
+  window.location.replace("https://ctf.bsidessf.net/");
+</script>
+
 ### E-mail ctf@bsidessf.org for questions.


### PR DESCRIPTION
This change redirects visitors to ctf.html to the scoreboard.  It will remain up until after the conference, at which point we'll revert this commit.