### PR TITLE
Updating the nav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,25 +1,34 @@
 - title: "Home"
   href: "/"
 
-- title: "Join us!"
-  href: "/volunteer"
 
-- title: "Tickets"
-  href: "/tickets"
-
-- title: "Schedule"
-  href: "/schedule"
-
-- title: "Friends"
-  href: "/friends"
-
-- title: "Sponsors"
-  href: "/sponsors"
-
-- title: "About"
+- title: Attend
   subcategories:
-    - subtitle: "BSidesSF"
-      subhref: "/about"
+    - subtitle: Schedule
+      subhref: /schedule
+    - subtitle: Tickets
+      subhref: /tickets
+
+- title: "Sponsors & Friends"
+  subcategories:
+    - subtitle: "Sponsors"
+      subhref: "/sponsors"
+    - subtitle: "Friends"
+      subhref: "/friends"
+
+- title: "Volunteers & Presenters"
+  subcategories:
+    - subtitle: "Volunteers"
+      subhref: "/volunteer"
+    - subtitle: "Presenters"
+      subhref: "/cfp"
+    - subtitle: "Organizers"
+      subhref: "/jobs"
+
+- title: About
+  subcategories:
+    - subtitle: BSidesSF
+      subhref: /about
     - subtitle: "Security BSides"
       external: "https://bsides.org"
     - subtitle: "News"
@@ -36,4 +45,3 @@
       subhref: "/about/contact"
     - subtitle: "Donate"
       subhref: "/donate"
-

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -4,10 +4,12 @@
 
 - title: Attend
   subcategories:
-    - subtitle: Schedule
-      subhref: /schedule
-    - subtitle: Tickets
-      subhref: /tickets
+    - subtitle: "Schedule"
+      subhref: "/schedule"
+    - subtitle: "Tickets"
+      subhref: "/tickets"
+    - subtitle: "Venue"
+      subhref: "/venue"
 
 - title: "Sponsors & Friends"
   subcategories:

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,6 +1,21 @@
 - title: "Home"
   href: "/"
 
+- title: "Join us!"
+  href: "/volunteer"
+
+- title: "Tickets"
+  href: "/tickets"
+
+- title: "Schedule"
+  href: "/schedule"
+
+- title: "Friends"
+  href: "/friends"
+
+- title: "Sponsors"
+  href: "/sponsors"
+
 - title: "About"
   subcategories:
     - subtitle: "BSidesSF"
@@ -22,21 +37,3 @@
     - subtitle: "Donate"
       subhref: "/donate"
 
-- title: "CFP"
-  subcategories:
-    - subtitle: "Talks / Workshops"
-      subhref: "/cfp"
-    - subtitle: "Villages"
-      subhref: "/cfp/villages"
-
-- title: "Join us!"
-  href: "/volunteer"
-
-- title: "Tickets"
-  href: "/tickets"
-
-- title: "Friends"
-  href: "/friends"
-
-- title: "Sponsors"
-  href: "/sponsors"

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -29,8 +29,8 @@
 
 - title: About
   subcategories:
-    - subtitle: BSidesSF
-      subhref: /about
+    - subtitle: "BSidesSF"
+      subhref: "/about"
     - subtitle: "Security BSides"
       external: "https://bsides.org"
     - subtitle: "News"

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,29 +1,7 @@
 - title: "Home"
   href: "/"
 
-
-- title: Attend
-  subcategories:
-    - subtitle: "Schedule"
-      subhref: "/schedule"
-    - subtitle: "Tickets"
-      subhref: "/tickets"
-    - subtitle: "Venue"
-      subhref: "/venue"
-
-- title: "Sponsors"
-  href: "/sponsors"
-- title: "Friends"
-  href: "/friends"
-
-- title: "Volunteers & Presenters"
-  subcategories:
-    - subtitle: "Volunteers"
-      subhref: "/volunteer"
-    - subtitle: "Organizers"
-      subhref: "/jobs"
-
-- title: About
+- title: "About"
   subcategories:
     - subtitle: "BSidesSF"
       subhref: "/about"
@@ -43,3 +21,21 @@
       subhref: "/about/contact"
     - subtitle: "Donate"
       subhref: "/donate"
+
+- title: "Attend"
+  subcategories:
+    - subtitle: "Schedule"
+      subhref: "/schedule"
+    - subtitle: "Tickets"
+      subhref: "/tickets"
+    - subtitle: "Venue"
+      subhref: "/venue"
+
+- title: "Volunteer"
+  href: "/volunteer"
+
+- title: "Friends"
+  href: "/friends"
+
+- title: "Sponsors"
+  href: "/sponsors"

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -11,19 +11,15 @@
     - subtitle: "Venue"
       subhref: "/venue"
 
-- title: "Sponsors & Friends"
-  subcategories:
-    - subtitle: "Sponsors"
-      subhref: "/sponsors"
-    - subtitle: "Friends"
-      subhref: "/friends"
+- title: "Sponsors"
+  href: "/sponsors"
+- title: "Friends"
+  href: "/friends"
 
 - title: "Volunteers & Presenters"
   subcategories:
     - subtitle: "Volunteers"
       subhref: "/volunteer"
-    - subtitle: "Presenters"
-      subhref: "/cfp"
     - subtitle: "Organizers"
       subhref: "/jobs"
 

--- a/_pages/jobs.md
+++ b/_pages/jobs.md
@@ -1,12 +1,17 @@
 ---
 layout: page
-title: "Jobs"
+title: "Organizer Roles"
 ---
 
 # Come help us plan the next BSidesSF!
 
 We're looking for a Few Good Humans to help us present the Next Big Thing.
 
-Please note that BSidesSF is a 100% volunteer-run organization. All roles are volunteer-based with no pay.
+BSidesSF is a 100% volunteer-run organization. All roles are volunteer-based with no pay.
 
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSevYdZizTCsUK5CaAMkNYOz0N3s7RsNfIL93KnpRy8cz70RVQ/viewform?embedded=true" width="800" height="1800" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+We are currently in the final stages or BSidesSF 2024 planning, and not taking on any additional organizers.  
+
+Volunteering is a good way to show your enthusiasm and ability to work with the group, especially if you can
+help with setup, teardown, and different tasks througout the event. All organizers work from the start of 
+setup through the end of teardown.
+

--- a/_posts/2024-03-13-join-us.md
+++ b/_posts/2024-03-13-join-us.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 category: post
-title: "BSidesSF 2024 Registration and Call for Volunteers"
+title: "BSidesSF 2024 Schedule, Registration, and Call for Volunteers"
 date: 2024-03-11
 ---
 


### PR DESCRIPTION
Apparently if we have too many characters in the nav bar, it wraps and becomes invisible and shoves page titles to be right-justified.

I've gathered the major topics under bigger headings, maintained the Home link, and also added in a link for "Organizers" (the /jobs page).  
Updated the /jobs page to say we're not hiring right now, volunteering is a way to get noticed.