### PR TITLE
Create pages for historical website from bsidessf events.

### DIFF
--- a/History.md
+++ b/History.md
@@ -24,7 +24,7 @@ Then we add it to the historical pages, and all should be good.
 | 2021 | Mar 6 & 9   | ef3d7aba58b55b56de0ecaf161efac27f508ffb6 | 
 | 2022 | Jun 4 & 5   | 154ecfeb0c50cdc7e80b47f36bb2742d4f901fbd |
 | 2023 | Apr 23 & 23 | 74123ef96c234ca2cce67c1640a924ad7d6975e7 |
-| 2024 | May 4 & 5   | 88b7d55a55f4d5d14d1caf260bf52c854e436431 |
+| 2024 | May 4 & 5   | d36e0e7ab55c8009246121eeb47c4ead4c633b15 |
 | 2025 | Apr 25 & 25 |
 
 
@@ -34,14 +34,11 @@ Then we add it to the historical pages, and all should be good.
   - `git log --decorate --until YYYY-MM-DD --graph --raw main`
 - Use the hash from the previoous command to check out the right version of the site
   - `git checkout <hash>`
-- **DO NOT SKIP** Make sure you have a completely CLEAN \_site directory. This is important.
-  - `bundle exec jekyll clean`
 - this builds the full site with a specific baseurl to support the changed directory root. This allows us to iframe it and have the site render as it was, and not use the current styles.
-  - `bundle exec jekyll build --baseurl / -d _archives/YYYY`
+  - `bundle exec jekyll build --baseurl /a/YYYY -d _archives/YYYY`
   - `git checkout <branch>` # this is the branch you are using to create the archive
 - Create the archive index page
-  - Be sure to replace YYYY with the appropriate year
-  - Create a file in \_archive for the year you are archiving `_archive/YYYY.md` using the template below
+  - Create a file in `/\_archive` for the year you are archiving `_archive/YYYY.md` using the template below
 
 ```
 ---
@@ -50,18 +47,16 @@ year: YYYY
 ---
 ```
 
-- Add an entry to \_data/history.yml
+- Add an entry to /\_data/history.yml
 - Verify that the archived site looks correct, especially at /a/YYYY.html
 
   - `bundle exec jekyll serve`
   - verify the About->Past Events page has your year and links on it
   - verify the website link works and is properly framed
   - verify all of the images and other assets are being properly loaded
+    - the sponsors page can be a sign of problems, make sure it shows all sponsors for that event
     - you can also search in `_archive/YYYY` for `src="/` or `href="/` which aren't point to /a/YYYY
 
-- You may need to edit any hardcoded referential paths that exist in `_archive/YYYY` to fix those links work properly inside the iframe
-
 - Look for items from the year you are archiving that can be removed, and delete them
-
 - Make the necessary commits to your branch
 - PR your changes to this repository

--- a/History.md
+++ b/History.md
@@ -1,0 +1,67 @@
+
+# Add to the history of BSidesSF
+
+Our basic method is to generate the static site from a previous year,
+with some modifications to have it serve properly from it's new location.
+Then we add it to the historical pages, and all should be good.
+
+### git hashes for each year
+
+
+| Year | Dates       | Commit to use                            |
+| :--: | :---------- | :--------------------------------------- |
+| 2010 | Mar 2 & 3   | N/A - pre gitlab pages work              |
+| 2011 | Feb 14 & 15 | N/A - pre gitlab pages work              |
+| 2012 | Feb 27 & 28 | N/A - pre gitlab pages work              |
+| 2013 | Feb 24 & 25 | N/A - pre gitlab pages work              |
+| 2014 | Feb 2 & 3   | N/A - pre gitlab pages work              |
+| 2015 | Apr 19 & 20 | N/A - pre gitlab pages work              |                                         
+| 2016 | Feb 28 & 29 | bc70ea06488b64721ceb6848310b3be49ce504b4 |
+| 2017 | Feb 12 & 12 | ff918e9033beb883836b71152031c7a4afaa62fc |
+| 2018 | Apr 15 & 16 | 26a2668a12d03135aff9fde3c126e39bdc246d93 |
+| 2019 | Mar 3 & 4   | f4c0ad8b29ef50658ffcf9327043848aef0a73f2 |
+| 2020 | Feb 23 & 24 | 97fc8093021afb200a579b77fd4ac95a89efb2f4 |
+| 2021 | Mar 6 & 9   | ef3d7aba58b55b56de0ecaf161efac27f508ffb6 | 
+| 2022 | Jun 4 & 5   | 154ecfeb0c50cdc7e80b47f36bb2742d4f901fbd |
+| 2023 | Apr 23 & 23 | 74123ef96c234ca2cce67c1640a924ad7d6975e7 |
+| 2024 | May 4 & 5   | 88b7d55a55f4d5d14d1caf260bf52c854e436431 |
+| 2025 | Apr 25 & 25 |
+
+
+##### Process (this is detailed an finicky so be careful to check your work)
+
+- Look for the last change during or right after the event to capture all of the changes that were made for the event.
+  - `git log --decorate --until YYYY-MM-DD --graph --raw main`
+- Use the hash from the previoous command to check out the right version of the site
+  - `git checkout <hash>`
+- **DO NOT SKIP** Make sure you have a completely CLEAN \_site directory. This is important.
+  - `bundle exec jekyll clean`
+- this builds the full site with a specific baseurl to support the changed directory root. This allows us to iframe it and have the site render as it was, and not use the current styles.
+  - `bundle exec jekyll build --baseurl / -d _archives/YYYY`
+  - `git checkout <branch>` # this is the branch you are using to create the archive
+- Create the archive index page
+  - Be sure to replace YYYY with the appropriate year
+  - Create a file in \_archive for the year you are archiving `_archive/YYYY.md` using the template below
+
+```
+---
+layout: archive
+year: YYYY
+---
+```
+
+- Add an entry to \_data/history.yml
+- Verify that the archived site looks correct, especially at /a/YYYY.html
+
+  - `bundle exec jekyll serve`
+  - verify the About->Past Events page has your year and links on it
+  - verify the website link works and is properly framed
+  - verify all of the images and other assets are being properly loaded
+    - you can also search in `_archive/YYYY` for `src="/` or `href="/` which aren't point to /a/YYYY
+
+- You may need to edit any hardcoded referential paths that exist in `_archive/YYYY` to fix those links work properly inside the iframe
+
+- Look for items from the year you are archiving that can be removed, and delete them
+
+- Make the necessary commits to your branch
+- PR your changes to this repository

--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
-BSidesSF Website
-=================
+# BSidesSF Website
 
 Theme is based on [Slim Pickins](https://chrisanthropic.github.io/slim-pickins-jekyll-theme/).
 
 Thanks to [ShmooCon](http://shmoocon.org/) for some navigation and content help.
 
-Running Locally
-=================
+# Running Locally
 
-If you haven't run this previoiusly, start with ```bundle install``` to install all of the gems necessary for the site.
+If you haven't run this previously, start with `bundle install` to install all of the gems necessary for the site.
 
-To run the site locally, run ```bundle exec jekyll serve``` or ```rake watch``` on the command line. The address will be listed as ```Server address``` in the output when this runs correctly.
+To run the site locally, run `bundle exec jekyll serve` or `rake watch` on the command line. The address will be listed as `Server address` in the output when this runs correctly.
 
-Adding pages
-============
+# Adding pages
 
-You can create a new page in \_pages, which will generate the page at the root of the site.  The top of your page (md or html) should look like:
+You can create a new page in \_pages, which will generate the page at the root of the site. The top of your page (md or html) should look like:
 
 ```
 ---
@@ -24,7 +21,8 @@ title: "My Page Title"
 ---
 ```
 
-After that you can put your content in either html or md form, depending on your file extension.   _filename_.md will become `filename.html`
+After that you can put your content in either html or md form, depending on your file extension. _filename_.md will become `filename.html`
 
-If you want the page to be linked, you should update __\_data/nav.yml__ with the proper
+If you want the page to be linked, you should update **\_data/nav.yml** with the proper
 location in the navigation.
+

--- a/_config.yml
+++ b/_config.yml
@@ -13,8 +13,6 @@ header_sm: images/bsides_logo_full-orangeblack.png
 header_med: images/bsides_logo_full-orangeblack.png
 header_large: images/bsides_logo_full-orangeblack.png
 header_xl: images/bsides_logo_full-orangeblack.png
-#header_left: ""
-#header_right: ""
 
 # Exclude our ruby stuff and other files
 exclude:
@@ -35,6 +33,10 @@ exclude:
 include: [.well-known]
 
 collections:
+  archive:
+    output: true
+    permalink: /a/:path
+
   pages:
     output: true
     permalink: /:path

--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ exclude:
 include: [.well-known]
 
 collections:
-  archive:
+  archives:
     output: true
     permalink: /a/:path
 

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ exclude:
     README.md,
     LICENSE,
     SECURITY.md,
+    History.md,
   ]
 include: [.well-known]
 

--- a/_data/history.yml
+++ b/_data/history.yml
@@ -7,27 +7,12 @@
 #
 ###
 
-- "year": "2024"
-  categories:
-    - title: "Videos"
-      external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RtlV2pwcvdbsCBc1Vb8kwVw"
-    - title: "Schedule"
-      external: "https://bsidessf2024.sched.com/"
-    - title: "Printed Program"
-      external: "https://drive.google.com/open?id=1Gk_oyUgeRDbM_BAon_ItQfNICnseZr6C"
-    - title: "Closing Ceremony Slides (external)"
-      external: https://docs.google.com/presentation/d/1m9zf2YEfG7WkhgV3zq9ECOfK24zWHbwPYesBqU_MQ9A/
-
 - "year": "2023"
   categories:
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RuQAuC0C4Q7Lk4eQluqIVzL"
     - title: "Schedule"
       external: "https://bsidessf2023.sched.com/"
-    - title: "Printed Program"
-      external: "https://drive.google.com/file/d/1W2YTJsKle0D-Y6jUkY3mpjPqWu2633zg/view?usp=drive_link"
-    - title: "Closing Remarks Slides"
-      external: "https://docs.google.com/presentation/d/13yhjMMH0qlAtu1g7ZaV_XHLxTBQMZ-47WpNhY50RRtI/edit?usp=sharing"
 
 - "year": "2022"
   categories:
@@ -37,12 +22,6 @@
       href: "/graphic-recordings/2022.html"
     - title: "Schedule"
       external: "https://bsidessf2022.sched.com/"
-    - title: "Printed Program"
-      external: "https://drive.google.com/file/d/14dw-J5v4r0vcdL7CmiWJfYrbmVoDmXia/view?usp=drive_link"
-    - title: "Program Map"
-      external: "https://drive.google.com/file/d/14ejQUhywZyLeD3VZO_DWXShNW57hnt6m/view?usp=sharing"
-    - title: "Closing Remarks Slides"
-      external: "https://docs.google.com/presentation/d/159zlpNuZlhwD7kB-zpTmhgub_UQmVf1grssI-rn7juo/edit?usp=sharing"
 
 - "year": "2021"
   categories:
@@ -50,8 +29,6 @@
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RvWn6Nne_Jj8IkLXZP3tgE6"
     - title: "Schedule"
       external: "https://bsidessf2021.sched.com/"
-    - title: "Closing Remarks Slides"
-      external: "https://docs.google.com/presentation/d/1ks4uKoXBxN5SyRM6OqeVPZDbjPPCTy_XzjyslN1mEpM/edit?usp=sharing"
 
 - "year": "2020"
   categories:
@@ -61,10 +38,8 @@
       href: "/graphic-recordings/2020.html"
     - title: "Schedule"
       external: "https://bsidessf2020.sched.com/"
-    - title: "Printed Program"
-      external: "https://drive.google.com/file/d/10fQ9EclEu9OguphU4ouDcEnyxRonSApp/view?usp=sharing"
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/132831939/BSidesSF2020"
+      external: "http://www.securitybsides.com/w/page/132831939/BSidesSF2020"
 
 - "year": "2019"
   categories:
@@ -74,12 +49,8 @@
       href: "/graphic-recordings/2019.html"
     - title: "Schedule"
       external: "https://bsidessf2019.sched.com/"
-    - title: "Printed Program"
-      external: "https://drive.google.com/file/d/1s9Y33utbFcbPW1KwlFOpRbGnSMfD6714/view?usp=sharing"
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/132743652/BSidesSF2019"
-    - title: "Closing Remarks Slides"
-      external: "https://docs.google.com/presentation/d/1s0Q7ogG0a_vmBexzsiplQMfGQJBLku3wPQrenOf_4-g/edit?usp=sharing"
+      external: "http://www.securitybsides.com/w/page/132743652/BSidesSF2019"
 
 - "year": "2018"
   categories:
@@ -90,60 +61,60 @@
     - title: "Schedule"
       external: "https://bsidessf2018.sched.com"
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/122163258/BSidesSF2018"
-    - title: "Closing Remarks Slides"
-      external: "https://docs.google.com/presentation/d/1JAn0jeGvhC4DaebJkv0zI1zffzmrDb66nQXB_hBPQyM/edit#slide=id.g37041135a4_0_76"
+      external: "http://www.securitybsides.com/w/page/122163258/BSidesSF2018"
 
 - "year": "2017"
   categories:
+    - title: "2017 Website"
+      href: "/a/2017.html"
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3Rsv-7uUugKLaz5CzQUnuAk8"
     - title: "Schedule"
       external: "https://bsidessf2017.sched.com/"
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/111866644/BSidesSF2017"
+      external: "http://www.securitybsides.com/w/page/111866644/BSidesSF2017"
 
 - year: "2016"
   categories:
+    - title: "2016 Website"
+      href: "/a/2016.html"
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RuSwuyJLQ6Hrx1ps9No6Lso"
     - title: "Schedule"
       external: "https://bsidessf2016.sched.com/"
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/103445197/BSidesSF2016"
+      external: "http://www.securitybsides.com/w/page/103445197/BSidesSF2016"
 
 - year: "2015"
   categories:
-    - title: "Videos"
-      external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RshjvKGmXcNAJtKKXdjXRf0"
     - title: "Schedule"
       external: "https://bsidessf2015.sched.com/"
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/90944586/BSidesSF2015"
+      external: "http://www.securitybsides.com/w/page/90944586/BSidesSF2015"
 
 - year: "2014"
   categories:
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/70849271/BSidesSF2014"
+      external: "http://www.securitybsides.com/w/page/70849271/BSidesSF2014"
 
 - year: "2013"
   categories:
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/35868077/BSidesSanFrancisco2013"
+      external: "http://www.securitybsides.com/w/page/35868077/BSidesSanFrancisco2013"
 
 - year: "2012"
   categories:
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RvjNaKOwD7qzJYnRaKYvSE4"
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/47572893/BSidesSanFrancisco2012"
+      external: "http://www.securitybsides.com/w/page/47572893/BSidesSanFrancisco2012"
 
 - year: "2011"
   categories:
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/56409738/BSidesSanFrancisco2011"
+      external: "http://www.securitybsides.com/w/page/56409738/BSidesSanFrancisco2011"
 
 - year: "2010"
   categories:
     - title: "Security BSides Wiki"
-      external: "https://bsides.org/w/page/12194147/BSidesSanFrancisco01"
+      external: "http://www.securitybsides.com/w/page/12194147/BSidesSanFrancisco01"

--- a/_data/history.yml
+++ b/_data/history.yml
@@ -7,12 +7,27 @@
 #
 ###
 
+- "year": "2024"
+  categories:
+    - title: "Videos"
+      external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RtlV2pwcvdbsCBc1Vb8kwVw"
+    - title: "Schedule"
+      external: "https://bsidessf2024.sched.com/"
+    - title: "Printed Program"
+      external: "https://drive.google.com/open?id=1Gk_oyUgeRDbM_BAon_ItQfNICnseZr6C"
+    - title: "Closing Ceremony Slides (external)"
+      external: https://docs.google.com/presentation/d/1m9zf2YEfG7WkhgV3zq9ECOfK24zWHbwPYesBqU_MQ9A/
+
 - "year": "2023"
   categories:
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RuQAuC0C4Q7Lk4eQluqIVzL"
     - title: "Schedule"
       external: "https://bsidessf2023.sched.com/"
+    - title: "Printed Program"
+      external: "https://drive.google.com/file/d/1W2YTJsKle0D-Y6jUkY3mpjPqWu2633zg/view?usp=drive_link"
+    - title: "Closing Remarks Slides"
+      external: "https://docs.google.com/presentation/d/13yhjMMH0qlAtu1g7ZaV_XHLxTBQMZ-47WpNhY50RRtI/edit?usp=sharing"
 
 - "year": "2022"
   categories:
@@ -22,6 +37,12 @@
       href: "/graphic-recordings/2022.html"
     - title: "Schedule"
       external: "https://bsidessf2022.sched.com/"
+    - title: "Printed Program"
+      external: "https://drive.google.com/file/d/14dw-J5v4r0vcdL7CmiWJfYrbmVoDmXia/view?usp=drive_link"
+    - title: "Program Map"
+      external: "https://drive.google.com/file/d/14ejQUhywZyLeD3VZO_DWXShNW57hnt6m/view?usp=sharing"
+    - title: "Closing Remarks Slides"
+      external: "https://docs.google.com/presentation/d/159zlpNuZlhwD7kB-zpTmhgub_UQmVf1grssI-rn7juo/edit?usp=sharing"
 
 - "year": "2021"
   categories:
@@ -29,6 +50,8 @@
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RvWn6Nne_Jj8IkLXZP3tgE6"
     - title: "Schedule"
       external: "https://bsidessf2021.sched.com/"
+    - title: "Closing Remarks Slides"
+      external: "https://docs.google.com/presentation/d/1ks4uKoXBxN5SyRM6OqeVPZDbjPPCTy_XzjyslN1mEpM/edit?usp=sharing"
 
 - "year": "2020"
   categories:
@@ -38,8 +61,10 @@
       href: "/graphic-recordings/2020.html"
     - title: "Schedule"
       external: "https://bsidessf2020.sched.com/"
+    - title: "Printed Program"
+      external: "https://drive.google.com/file/d/10fQ9EclEu9OguphU4ouDcEnyxRonSApp/view?usp=sharing"
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/132831939/BSidesSF2020"
+      external: "https://bsides.org/w/page/132831939/BSidesSF2020"
 
 - "year": "2019"
   categories:
@@ -49,8 +74,12 @@
       href: "/graphic-recordings/2019.html"
     - title: "Schedule"
       external: "https://bsidessf2019.sched.com/"
+    - title: "Printed Program"
+      external: "https://drive.google.com/file/d/1s9Y33utbFcbPW1KwlFOpRbGnSMfD6714/view?usp=sharing"
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/132743652/BSidesSF2019"
+      external: "https://bsides.org/w/page/132743652/BSidesSF2019"
+    - title: "Closing Remarks Slides"
+      external: "https://docs.google.com/presentation/d/1s0Q7ogG0a_vmBexzsiplQMfGQJBLku3wPQrenOf_4-g/edit?usp=sharing"
 
 - "year": "2018"
   categories:
@@ -61,60 +90,60 @@
     - title: "Schedule"
       external: "https://bsidessf2018.sched.com"
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/122163258/BSidesSF2018"
+      external: "https://bsides.org/w/page/122163258/BSidesSF2018"
+    - title: "Closing Remarks Slides"
+      external: "https://docs.google.com/presentation/d/1JAn0jeGvhC4DaebJkv0zI1zffzmrDb66nQXB_hBPQyM/edit#slide=id.g37041135a4_0_76"
 
 - "year": "2017"
   categories:
-    - title: "2017 Website"
-      href: "/a/2017.html"
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3Rsv-7uUugKLaz5CzQUnuAk8"
     - title: "Schedule"
       external: "https://bsidessf2017.sched.com/"
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/111866644/BSidesSF2017"
+      external: "https://bsides.org/w/page/111866644/BSidesSF2017"
 
 - year: "2016"
   categories:
-    - title: "2016 Website"
-      href: "/a/2016.html"
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RuSwuyJLQ6Hrx1ps9No6Lso"
     - title: "Schedule"
       external: "https://bsidessf2016.sched.com/"
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/103445197/BSidesSF2016"
+      external: "https://bsides.org/w/page/103445197/BSidesSF2016"
 
 - year: "2015"
   categories:
+    - title: "Videos"
+      external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RshjvKGmXcNAJtKKXdjXRf0"
     - title: "Schedule"
       external: "https://bsidessf2015.sched.com/"
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/90944586/BSidesSF2015"
+      external: "https://bsides.org/w/page/90944586/BSidesSF2015"
 
 - year: "2014"
   categories:
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/70849271/BSidesSF2014"
+      external: "https://bsides.org/w/page/70849271/BSidesSF2014"
 
 - year: "2013"
   categories:
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/35868077/BSidesSanFrancisco2013"
+      external: "https://bsides.org/w/page/35868077/BSidesSanFrancisco2013"
 
 - year: "2012"
   categories:
     - title: "Videos"
       external: "https://www.youtube.com/playlist?list=PLbZzXF2qC3RvjNaKOwD7qzJYnRaKYvSE4"
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/47572893/BSidesSanFrancisco2012"
+      external: "https://bsides.org/w/page/47572893/BSidesSanFrancisco2012"
 
 - year: "2011"
   categories:
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/56409738/BSidesSanFrancisco2011"
+      external: "https://bsides.org/w/page/56409738/BSidesSanFrancisco2011"
 
 - year: "2010"
   categories:
     - title: "Security BSides Wiki"
-      external: "http://www.securitybsides.com/w/page/12194147/BSidesSanFrancisco01"
+      external: "https://bsides.org/w/page/12194147/BSidesSanFrancisco01"

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+
+  <body>
+    <main class="wrap">
+      {% include header.html %}
+      {% include navigation.html %}
+      {{ content }}
+    </main>
+  </body>
+</html>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -6,6 +6,21 @@
     <main class="wrap">
       {% include header.html %}
       {% include navigation.html %}
+      <div class="archive banner">
+        <strong class="banner">
+          You're viewing an archive of the {{ page.year }} website.
+        </strong>
+      </div>
+      <div class="archive">
+        <base name="h_frame_{{page.year}}" href="/a/{{ page.year }}">
+        <iframe
+          src="/a/{{ page.year }}"
+          width="100%"
+          height="1024"
+          name="h_frame_{{page.year}}">
+            Loading {{ page.year }} site...
+        </iframe>
+      </div>
       {{ content }}
     </main>
   </body>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -67,10 +67,7 @@
 
 // Header
 header[role="banner"] {
-//  background: linear-gradient($header-gradient-start, $header-gradient-end);
-  background: $header-background-img;
-  background-size: contain;
-  background-size: cover;
+  background: linear-gradient($header-gradient-start, $header-gradient-end);
 }
 
 // Footer
@@ -278,4 +275,23 @@ div.imgdiv {
       border-top: 10px solid #fff;
     }
   }
+}
+
+div.archive {
+  width: 80%;
+  height: 1024;
+  margin: auto;
+}
+
+div.banner {
+  background: $secondary-color;
+  color: $primary-color;
+  margin-bottom: 10px;
+  margin-top: 10px;
+  text-align: center;
+  border: 10px solid $secondary-color;
+}
+
+strong.banner {
+  font-size: $large-font-size;
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,10 +1,7 @@
 // Base Colors
-//$primary-color: #272727; // black
-//$secondary-color: #CD502B; // orange
-//$complimentary-color: #fff; // white
-$primary-color: #000; // black
-$secondary-color: #be202e; // orange
-$complimentary-color: #d0cbc0; // white
+$primary-color: #272727; // black
+$secondary-color: #CD502B; // orange
+$complimentary-color: #fff; // white
 $body-bg: #fff; // white
 $body-font-color: $primary-color;
 
@@ -17,6 +14,7 @@ $link-visited-color: darken($secondary-color, 10%);
 $base-font-family: Helvetica, Arial, sans-serif;
 $base-font-size: 1.0em;
 $small-font-size: $base-font-size * 0.875;
+$large-font-size: 2.5em;
 $base-line-height: 1.5;
 
 
@@ -38,10 +36,9 @@ $socials-border-color: #fff; // white
 $spacing-unit: 30px;
 
 // Header
-$header-gradient-start: #000; // white
+$header-gradient-start: #fff; // white
 $header-gradient-end: #fff; // white
-// $header-background-img: url('/images/header_background_2024.jpg');
-$header-background-img: "";
+$header-background-img: "../images/header_background_2024.jpg";
 
 // Footer
 $footer-height: 54px;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,7 +1,10 @@
 // Base Colors
-$primary-color: #272727; // black
-$secondary-color: #CD502B; // orange
-$complimentary-color: #fff; // white
+//$primary-color: #272727; // black
+//$secondary-color: #CD502B; // orange
+//$complimentary-color: #fff; // white
+$primary-color: #000; // black
+$secondary-color: #be202e; // orange
+$complimentary-color: #d0cbc0; // white
 $body-bg: #fff; // white
 $body-font-color: $primary-color;
 
@@ -14,7 +17,6 @@ $link-visited-color: darken($secondary-color, 10%);
 $base-font-family: Helvetica, Arial, sans-serif;
 $base-font-size: 1.0em;
 $small-font-size: $base-font-size * 0.875;
-$large-font-size: 2.5em;
 $base-line-height: 1.5;
 
 
@@ -36,9 +38,10 @@ $socials-border-color: #fff; // white
 $spacing-unit: 30px;
 
 // Header
-$header-gradient-start: #fff; // white
+$header-gradient-start: #000; // white
 $header-gradient-end: #fff; // white
-$header-background-img: "../images/header_background_2024.jpg";
+// $header-background-img: url('/images/header_background_2024.jpg');
+$header-background-img: "";
 
 // Footer
 $footer-height: 54px;


### PR DESCRIPTION
Adds instructions on how to set up a new year's archival pages.
Cleans up the documentation for contributing to the website slightly.
Creates a new collection for archives - static sites from previous years
Creates a layout the wraps the archived sites in an iframe, with a big banner so people don't get confused
Adds styling for archive wrapping page.