### PR TITLE
Markdown format issue on Sponsors

### DIFF
--- a/_pages/sponsors.md
+++ b/_pages/sponsors.md
@@ -5,9 +5,7 @@ title: "Sponsors"
 
 Our fantastic sponsors make BSidesSF financially possible year after year, none of this is possible without them!
 
-<h3>
-  <p>Sponsorships for BSidesSF 2025 are sold out. Considering joining us as a <a href="/friends">Friend of BSidesSF</a>.
-</h3>
+### Sponsorships for BSidesSF 2025 are sold out. Considering joining us as a [Friend of BSidesSF](/friends).
 
 {% for class in site.data.sponsors.levels %}
 


### PR DESCRIPTION
Causes the display of a dangling `</h3>` because of a missing `</p>`. Rewritten as Markdown.